### PR TITLE
Merge branch 'frontend/feature/account-screen' into frontend

### DIFF
--- a/frontend/lib/core/routing/app_router.dart
+++ b/frontend/lib/core/routing/app_router.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:frontend/features/account/presentation/pages/account_page.dart';
 import 'package:frontend/features/auth/presentation/pages/signin_page.dart';
 import 'package:frontend/features/chat/presentation/pages/chat_page.dart';
 import 'package:frontend/features/map/presentation/pages/map_page.dart';
@@ -12,6 +13,7 @@ GoRouter buildRouter() => GoRouter(
     GoRoute(path: '/signin', builder: (_, __) => const SignInPage()),
     GoRoute(path: '/map', builder: (_, __) => const MapPage()),
     GoRoute(path: '/chat', builder: (_, __) => const ChatPage()),
+    GoRoute(path: '/myaccount', builder: (_, __) => const AccountPage()),
   ],
   errorBuilder: (_, state) => Scaffold(
     appBar: AppBar(title: const Text('Ops')),

--- a/frontend/lib/features/account/presentation/pages/account_page.dart
+++ b/frontend/lib/features/account/presentation/pages/account_page.dart
@@ -1,0 +1,160 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import '../../../../../core/config/app_colors.dart';
+
+class AccountPage extends StatefulWidget {
+  const AccountPage({super.key});
+
+  @override
+  State<AccountPage> createState() => _AccountPageState();
+}
+
+class _AccountPageState extends State<AccountPage> {
+  int _currentIndex = 3;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        backgroundColor: AppColors.navy,
+        elevation: 0,
+        title: const Text(
+          "Minha Conta",
+          style: TextStyle(color: Colors.white, fontWeight: FontWeight.w600),
+        ),
+        centerTitle: true,
+        iconTheme: const IconThemeData(color: Colors.white),
+      ),
+      body: SingleChildScrollView(
+        child: Column(
+          children: [
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
+              color: AppColors.navy,
+              child: Column(
+                children: [
+                  const CircleAvatar(
+                    radius: 42,
+                    backgroundColor: Colors.black,
+                    child: Icon(Icons.person, color: Colors.white, size: 42),
+                  ),
+                  const SizedBox(height: 12),
+                  const Text(
+                    "Pedro Miguel Radwanski",
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.w700,
+                      fontSize: 18,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  const Text(
+                    "Doador",
+                    style: TextStyle(color: Colors.white70, fontSize: 14),
+                  ),
+                  const SizedBox(height: 16),
+                  OutlinedButton(
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor: Colors.white,
+                      side: const BorderSide(color: Colors.white70),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(30),
+                      ),
+                    ),
+                    onPressed: () {
+                      // TODO: ação editar perfil
+                    },
+                    child: const Text("Editar Perfil"),
+                  ),
+                ],
+              ),
+            ),
+
+            const SizedBox(height: 16),
+            _buildInfoTile("Nome", "Pedro Miguel Radwanski"),
+            _buildInfoTile("CPF", "123.456.789-00"),
+            _buildInfoTile("E-mail", "pedro.miguel@email.com"),
+            _buildInfoTile("Telefone", "(41) 99999-9999"),
+            _buildInfoTile("Endereço", "Rua XV de Novembro, 123 - Curitiba/PR"),
+
+            const SizedBox(height: 20),
+
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: ElevatedButton.icon(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.red,
+                  foregroundColor: Colors.white,
+                  minimumSize: const Size.fromHeight(48),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+                onPressed: () {
+                  context.go('/signin');
+                },
+                icon: const Icon(Icons.exit_to_app),
+                label: const Text(
+                  "Sair",
+                  style: TextStyle(fontWeight: FontWeight.w700),
+                ),
+              ),
+            ),
+            const SizedBox(height: 20),
+          ],
+        ),
+      ),
+
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _currentIndex,
+        onTap: (i) {
+          setState(() => _currentIndex = i);
+          if (i == 0) context.go('/map');
+          if (i == 1) context.go('/services');
+          if (i == 2) context.go('/activity');
+          if (i == 3) context.go('/account');
+        },
+        type: BottomNavigationBarType.fixed,
+        selectedItemColor: AppColors.navy,
+        unselectedItemColor: Colors.black54,
+        items: const [
+          BottomNavigationBarItem(
+            icon: Icon(Icons.home_outlined),
+            activeIcon: Icon(Icons.home),
+            label: 'Home',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.grid_view_outlined),
+            label: 'Serviços',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.receipt_long_outlined),
+            label: 'Atividades',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.person_outline),
+            label: 'Conta',
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildInfoTile(String label, String value) {
+    return Column(
+      children: [
+        ListTile(
+          leading: const Icon(Icons.info_outline, color: Colors.grey),
+          title: Text(
+            label,
+            style: const TextStyle(fontWeight: FontWeight.w500),
+          ),
+          subtitle: Text(value, style: const TextStyle(color: Colors.black87)),
+        ),
+        const Divider(height: 1, thickness: 0.5),
+      ],
+    );
+  }
+}

--- a/frontend/lib/features/map/presentation/pages/map_page.dart
+++ b/frontend/lib/features/map/presentation/pages/map_page.dart
@@ -85,12 +85,10 @@ class _MapPageState extends State<MapPage> {
       body: SafeArea(
         child: Column(
           children: [
-            // --------- HEADER (branco) ----------
             Padding(
               padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
               child: Row(
                 children: [
-                  // pill de busca
                   Expanded(
                     child: Container(
                       height: 48,
@@ -152,9 +150,7 @@ class _MapPageState extends State<MapPage> {
               ),
             ),
 
-            // --------- MAPA (não ocupa a tela toda) ----------
-            // Usa Expanded para preencher o espaço ENTRE header e footer.
-            // Envolvido num card com bordas arredondadas.
+
             Expanded(
               child: Padding(
                 padding: const EdgeInsets.fromLTRB(0, 12, 0, 0),
@@ -185,7 +181,6 @@ class _MapPageState extends State<MapPage> {
                         ],
                       ),
 
-                      // botão "minha localização" dentro do card do mapa
                       Positioned(
                         right: 12,
                         bottom: 12,
@@ -214,11 +209,24 @@ class _MapPageState extends State<MapPage> {
         ),
       ),
 
-      // --------- FOOTER (sempre no final da tela) ----------
       bottomNavigationBar: BottomNavigationBar(
         currentIndex: _currentIndex,
         onTap: (i) {
-          /* ... */
+          setState(() => _currentIndex = i);
+          switch (i) {
+            case 0:
+              context.go('/map');
+              break;
+            // case 1:
+            //   context.go('/services'); 
+            //   break;
+            // case 2:
+            //   context.go('/activities'); 
+            //   break;
+            case 3:
+              context.go('/myaccount'); 
+              break;
+          }
         },
         type: BottomNavigationBarType.fixed,
         selectedItemColor: AppColors.navy,


### PR DESCRIPTION
Implemented the initial Account screen. The page includes a profile header with avatar, name, 
and account type (donor/collector), followed by detailed user information such as CPF/CNPJ, 
email, phone, and address. Added edit profile and logout actions. Integrated bottom navigation 
bar for consistency with other main screens.